### PR TITLE
Change license to CC BY 4.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,67 +1,9 @@
 # Licenses
 
-Source code files and code snippets included in this project are
-licensed under a [BSD 3-clause license with a patent
-grant](#bsd-3-clause-license-with-patent-grant).  All other content in
-this project, including content produced directly from unmodified
-source code and code snippets, is licensed under a [Creative Commons
-Attribution 4.0 International (CC BY 4.0)
-license](https://creativecommons.org/licenses/by/4.0/).
-
 Copyright (c) 2017, PlasmaPy Developers.
 
-## BSD 3-clause license with patent grant
+Except as otherwise noted, content in this repository is licensed
+under a [Creative Commons Attribution 4.0 International (CC BY 4.0)
+license](https://creativecommons.org/licenses/by/4.0/).
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
-
-* Neither the name of PlasmaPy nor the names of its contributors may
-  be used to endorse or promote products derived from this software
-  without specific prior written permission.
-
-Subject to the terms and conditions of this license, each copyright
-holder and contributor hereby grants to those receiving rights under
-this license a perpetual, worldwide, non-exclusive, no-charge,
-royalty-free, irrevocable (except for failure to satisfy the
-conditions of this license) patent license to make, have made, use,
-offer to sell, sell, import, and otherwise transfer this software,
-where such license applies only to those patent claims, already
-acquired or hereafter acquired, licensable by such copyright holder or
-contributor that are necessarily infringed by:
-
-(a) their Contribution(s) (the licensed copyrights of copyright
-holders and non-copyrightable additions of contributors, in source or
-binary form) alone; or
-
-(b) combination of their Contribution(s) with the work of authorship
-to which such Contribution(s) was added by such copyright holder or
-contributor, if, at the time the Contribution is added, such addition
-causes such combination to be necessarily infringed. The patent
-license shall not apply to any other combinations which include the
-Contribution.
-
-Except as expressly stated above, no rights or licenses from any
-copyright holder or contributor is granted under this license, whether
-expressly, by implication, estoppel or otherwise.
-
-### Disclaimer
-
-This software is provided by the copyright holders and contributors
-"as is" and any express or implied warranties, including, but not
-limited to, the implied warranties of merchantability and fitness for
-a particular purpose are disclaimed. In no event shall the copyright
-holder or contributors be liable for any direct, indirect, incidental,
-special, exemplary, or consequential damages (including, but not
-limited to, procurement of substitute goods or services; loss of use,
-data, or profits; or business interruption) however caused and on any
-theory of liability, whether in contract, strict liability, or tort
-(including negligence or otherwise) arising in any way out of the use
-of this software, even if advised of the possibility of such damage.
+[![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PlasmaPy Enhancement Proposals
 
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](./LICENSE.md)
 
-A repository which will eventually be used for PlasmaPy Enhancement Proposals.
+This repository contains PlasmaPy Enhancement Proposals (PLEPs).
+[PLEP 0](PLEP-0000.md) contains an index of PLEPs.


### PR DESCRIPTION
This pull request changes the license of this repository into the Creative Commons Attribution 4.0 International (CC BY 4.0) license.  Before this, the BSD 3-clause license with an explicit patent grant was used to cover source code files and code snippets.  However, this repository is not a software repository, and using an open source license for software is not necessary.