### PR TITLE
Add PLEP7 author to convert_to_pdf.sh

### DIFF
--- a/convert_to_pdf.sh
+++ b/convert_to_pdf.sh
@@ -27,6 +27,7 @@ authors=( \
     [0004]="Nicholas A. Murphy" \
     [0005]="Nicholas A. Murphy and Stuart J. Mumford" \
     [0006]="Andrew J. Leonard" \
+    [0007]="Erik T. Everson" \
 )
 
 for rstfile in PLEP-????.rst; do


### PR DESCRIPTION
Add the PLEP7 authorship to the the `authors` list in `convert_to_pdf.sh`.  This was missed in the PLEP7 PR #26.