### PR TITLE
Nominate Erik to a member of the Coordinating Committee

### DIFF
--- a/PLEP-0003.rst
+++ b/PLEP-0003.rst
@@ -9,7 +9,7 @@ PLEP-0003 – Members of Coordinating Committee
 +-------------------+---------------------------------------------+
 | date created      | 2017-09-29                                  |
 +-------------------+---------------------------------------------+
-| date last revised | 2018-09-26                                  |
+| date last revised | 2020-06-23                                  |
 +-------------------+---------------------------------------------+
 | type              | informational                               |
 +-------------------+---------------------------------------------+
@@ -38,6 +38,8 @@ The PlasmaPy Coordinating Committee includes the following members:
 | Tulasi Parashar  | University of Delaware                      | `@tulasinandan <https://github.com/tulasinandan>`__       |
 +------------------+---------------------------------------------+-----------------------------------------------------------+
 | Dominik Stańczak | University of Warsaw                        | `@StanczakDominik <https://github.com/StanczakDominik>`__ |
++------------------+---------------------------------------------+-----------------------------------------------------------+
+| Erik T. Everson  | University of California, Los Angeles       | `@rocco8773 <https://github.com/rocco8773>`__             |
 +------------------+---------------------------------------------+-----------------------------------------------------------+
 
 The institutions of Coordinating Committee members are included for


### PR DESCRIPTION
This is the official nomination and vote to add Erik Everson (@rocco8773) to list of PlasmaPy Coordinating Committee Members.

What's changed:

- [x] Add Erik T. Everson to Coordinating Committee on PLEP3
- [x] Update PLEP 3 last revised date
- [ ] Add updated PLEP 3 to zenodo and get new DOI
- [ ] Update PLEP 3 DOI
- [ ] Update PLEP 3 DOI on the `README.rst`
- [ ] Update PLEP 3 DOI on the `PLEP-0000.rst`